### PR TITLE
fix(articles): zoom the spread comparison instead of clipping it

### DIFF
--- a/vignettes/articles/model-visualization.Rmd
+++ b/vignettes/articles/model-visualization.Rmd
@@ -119,8 +119,10 @@ gf_histogram(~Thumb, data = Fingers, binwidth = 5) %>%
 ```
 
 Two groups with the same mean and different spread get rulers of different
-lengths, which is the comparison the ruler exists to make. Fixing the axis with
-`gf_lims()` keeps the two plots on the same scale.
+lengths, which is the comparison the ruler exists to make. Zooming both to the
+same x range keeps them comparable. `coord_cartesian()` does that by changing
+what you see; `gf_lims()` would do it by discarding anything outside the range,
+which is not what you want when the whole point is to compare distributions.
 
 ```{r}
 set.seed(154)
@@ -129,12 +131,12 @@ set.seed(141)
 feedback <- data.frame(median_time = round(rnorm(100, 13, 3), 1))
 
 gf_histogram(~median_time, data = no_feedback, binwidth = 1) %>%
-  gf_lims(x = c(0, 31)) %>%
+  gf_refine(coord_cartesian(xlim = c(0, 31))) %>%
   gf_model(lm(median_time ~ NULL, data = no_feedback)) %>%
   gf_sd_ruler(color = "red", size = 2)
 
 gf_histogram(~median_time, data = feedback, binwidth = 1) %>%
-  gf_lims(x = c(0, 31)) %>%
+  gf_refine(coord_cartesian(xlim = c(0, 31))) %>%
   gf_model(lm(median_time ~ NULL, data = feedback)) %>%
   gf_sd_ruler(color = "red", size = 2)
 ```


### PR DESCRIPTION
The model-visualization guide compares two groups with the same mean and different spread, pinning both to the same x range so the rulers are comparable. It pinned them with `gf_lims()`, which prints this into the rendered page:

```
#> Removed 2 rows containing missing values or values outside the scale range
```

On a page teaching people how to read a distribution, a message about removed rows reads as data loss.

## What is actually happening

`gf_lims()` sets scale limits, and a scale limit *discards* data outside it. Here the discarded rows are only the empty bins `stat_bin` pads each end of the range with — all 100 observations are retained and every bar is drawn. So the message is not lying, exactly, but what it describes is invisible and irrelevant, and a reader has no way to tell that from the text.

`coord_cartesian()` changes the view without touching the data. Same range, same picture, no message:

```
gf_lims(x = c(0, 31))          1 message
coord_cartesian(xlim = c(0, 31))   0 messages
```

## Why it is worth a commit of its own

The distinction generalises beyond this page. Any time you pin an axis to make two plots comparable, `lims()` is the version that can silently drop what falls outside — which is the opposite of what you want when the comparison *is* the point. The surrounding prose now says so, since a reader who has just been shown two pinned plots is exactly the reader who will go and pin a third.

Split out from the examples work rather than squashed into it, because this is a rendering fix and would be invisible to anyone scanning the history for one.

## Verification

- `FAIL 0 | WARN 0 | SKIP 0 | PASS 381`
- The article renders with no console output
- One file, six lines
